### PR TITLE
Add list selector for Ledger derivation modes

### DIFF
--- a/src/interactive-cli.ts
+++ b/src/interactive-cli.ts
@@ -294,6 +294,8 @@ export async function interactiveCli(baseargv: string[]) {
 async function connectWallet(): Promise<ConnectWalletInterface> {
   const walletPrompt = await prompts.connectWallet()
   const wallet = walletPrompt.wallet
+  const derivation = walletPrompt.derivation
+
   if (wallet == Object.keys(walletConstants)[2]) {
     console.log(`${colorCodes.redColor}Warning: You are connecting using your private key which is not recommended`)
     const pvtKeyPath = await prompts.pvtKeyPath()
@@ -327,7 +329,7 @@ async function connectWallet(): Promise<ConnectWalletInterface> {
       network = await selectNetwork()
 
       console.log("Fetching Addresses...")
-      const pathList: DerivedAddress[] = await getPathsAndAddresses(network)
+      const pathList: DerivedAddress[] = await getPathsAndAddresses(network, derivation)
       const choiceList = await createChoicesFromAddress(pathList)
       const selectedAddress = await prompts.selectAddress(choiceList)
 

--- a/src/ledger/utils.ts
+++ b/src/ledger/utils.ts
@@ -141,13 +141,19 @@ export function expandDerivationPath(derivationPath: string) {
  * @param {string} network The network for which addresses need to be derived
  * @returns {DerivedAddress[]} Retuns a list of objects where every object contains an ethAddress and the corresponsing derivation path
  */
-export async function getPathsAndAddresses(network: string): Promise<DerivedAddress[]> {
-  const BASE_PATH = "m/44'/60'/0'/0/"
+export async function getPathsAndAddresses(network: string, derivationMode: string = "default"): Promise<DerivedAddress[]> {
+  const LEDGER_LIVE_BASE_PATH = "m/44'/60'/" // Full: m/44'/60'/*'/0/0
+  const BIP44_BASE_PATH = "m/44'/60'/0'/0/" // Full: m/44'/60'/0'/0/*
   const PATH_LIST = []
 
   for (let i = 0; i < 10; i++) {
-    PATH_LIST.push(BASE_PATH + i.toString())
+    if (derivationMode == "ledger_live") {
+      PATH_LIST.push(LEDGER_LIVE_BASE_PATH + i.toString() + "'/0/0")
+    } else {
+      PATH_LIST.push(BIP44_BASE_PATH + i.toString())
+    }
   }
+
   const results: DerivedAddress[] = [];
 
   for (const path of PATH_LIST) {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,6 +1,6 @@
 import inquirer from 'inquirer';
 import { colorCodes } from './constants';
-import { taskConstants, networkConstants, walletConstants } from './screenConstants';
+import { taskConstants, networkConstants, walletConstants, derivationModeConstants } from './screenConstants';
 
 
 /**
@@ -18,6 +18,18 @@ export const prompts = {
         ],
         filter: (val: string) => {
           const key = Object.keys(walletConstants).find(key => walletConstants[key] == val)
+          return key
+        }
+      },
+      {
+        type: 'list',
+        name: 'derivation',
+        message: `${colorCodes.magentaColor}Choose derivation path...${colorCodes.resetColor}`,
+        choices: [
+          ...Object.values(derivationModeConstants)
+        ],
+        filter: (val: string) => {
+          const key = Object.keys(derivationModeConstants).find(key => derivationModeConstants[key] == val)
           return key
         }
       },

--- a/src/screenConstants.ts
+++ b/src/screenConstants.ts
@@ -5,32 +5,40 @@ import { colorCodes } from './constants';
  * @description Object that constains list of tasks user can perform as its keys and their corresponding CLI commands as values.
  */
 export const taskConstants: ScreenConstantsInterface = {
-    'View chain addresses': 'addresses',
-    'Check on-chain balance': "balance",
-    'Get network info': "network",
-    'Get validator info': "validators",
-    'Move assets from C-chain to P-chain': 'CP',
-    'Move assets from P-chain to C-chain': "PC",
-    'Add a validator node': "stake",
-    'Delegate to a validator node': "delegate",
-    'Get Mirror fund details': 'mirror',
-    'Claim Rewards':"rewards"
+  'View chain addresses': 'addresses',
+  'Check on-chain balance': "balance",
+  'Get network info': "network",
+  'Get validator info': "validators",
+  'Move assets from C-chain to P-chain': 'CP',
+  'Move assets from P-chain to C-chain': "PC",
+  'Add a validator node': "stake",
+  'Delegate to a validator node': "delegate",
+  'Get Mirror fund details': 'mirror',
+  'Claim Rewards': "rewards"
 }
 
 /**
  * @description Constant object which contains the supported networks and their corresponding formatted output names as key-value pairs.
  */
 export const networkConstants: ScreenConstantsInterface = {
-    "flare": `Flare ${colorCodes.greenColor}(Mainnet)${colorCodes.resetColor}`,
-    "costwo": `Coston2 ${colorCodes.yellowColor}(Testnet)${colorCodes.resetColor}`,
-    "localflare": `LocalHost ${colorCodes.redColor}(for development only)${colorCodes.resetColor}`
+  "flare": `Flare ${colorCodes.greenColor}(Mainnet)${colorCodes.resetColor}`,
+  "costwo": `Coston2 ${colorCodes.yellowColor}(Testnet)${colorCodes.resetColor}`,
+  "localflare": `LocalHost ${colorCodes.redColor}(for development only)${colorCodes.resetColor}`
 }
 
 /**
  * @description Constant object which contains the supported wallets and their corresponding formatted output names as key-value pairs.
  */
 export const walletConstants: ScreenConstantsInterface = {
-    "ledger": 'Ledger',
-    "publicKey": 'Public Key',
-    "privateKey": `Private Key ${colorCodes.redColor}(not recommended)`
+  "ledger": 'Ledger',
+  "publicKey": 'Public Key',
+  "privateKey": `Private Key ${colorCodes.redColor}(not recommended)`
+}
+
+/**
+ * @description Constant object which contains the supported wallet derivation path modes and their corresponding formatted output names as key-value pairs.
+ */
+export const derivationModeConstants: ScreenConstantsInterface = {
+  "bip44": 'BIP44 (Default)',
+  "ledger_live": 'Ledger Live',
 }


### PR DESCRIPTION
Previously when selecting Ledger as the wallet to connect it would default to the BIP44 derivation path but another common derivation path used by Ledger is the Ledger Live derivation path which is `m/44'/60'/*'/0/0` compared to BIP44 `m/44'/60'/0'/0/*`. 

A new prompt has been added to ask which derivation path to use which defaults to BIP44 but also offers Ledger Live derivation path. The mode is checked in the Ledgers utils _getPathsAndAddresses_ module function and addressed accordingly. 